### PR TITLE
fix memory leak

### DIFF
--- a/Source/FFmpeg/Wrappers/FFmpegFrame.swift
+++ b/Source/FFmpeg/Wrappers/FFmpegFrame.swift
@@ -184,7 +184,10 @@ class FFmpegFrame {
         }
         
         // Receive the frame from the codec context.
-        guard avcodec_receive_frame(codecCtx, pointer).isNonNegative else {return nil}
+        guard avcodec_receive_frame(codecCtx, pointer).isNonNegative else {
+            av_frame_free(&pointer)
+            return nil
+        }
         
         self.sampleFormat = sampleFormat
         self.firstSampleIndex = 0


### PR DESCRIPTION
After initialization fails,  need to release the memory of the frame, otherwise there will be a memory leak.